### PR TITLE
Add link directly to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ features for JSON Pointers as well.
 
 ## Documentation
 
-The documentation for this project can be found here: https://github.com/whitlockjc/json-refs/blob/master/docs/README.md .
+The documentation for this project can be found here: <https://github.com/whitlockjc/json-refs/blob/master/docs/README.md>.
 
-The API can be found at https://github.com/whitlockjc/json-refs/blob/master/docs/API.md .
+The API can be found at <https://github.com/whitlockjc/json-refs/blob/master/docs/API.md>.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ features for JSON Pointers as well.
 
 ## Documentation
 
-The documentation for this project can be found here: https://github.com/whitlockjc/json-refs/blob/master/docs/README.md
+The documentation for this project can be found here: https://github.com/whitlockjc/json-refs/blob/master/docs/README.md .
+
+The API can be found at https://github.com/whitlockjc/json-refs/blob/master/docs/API.md .
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ features for JSON Pointers as well.
 
 ## Documentation
 
-The documentation for this project can be found here: <https://github.com/whitlockjc/json-refs/blob/master/docs/README.md>.
+The documentation for this project can be found at <https://github.com/whitlockjc/json-refs/blob/master/docs/README.md>.
 
 The API can be found at <https://github.com/whitlockjc/json-refs/blob/master/docs/API.md>.
 


### PR DESCRIPTION
It is more convenient, I think, to be able to go directly to the API.