### PR TITLE
Fix for bug where refs property does not include invalid ref, if invalid reference is part of a nested file, even if includeInvalid option is set to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -328,6 +328,9 @@ function buildRefModel (document, options, metadata) {
       // Record reference metadata
       metadata.refs[refKey] = refDetails;
 
+      // Record dependency (relative to the document's sub-document path)
+      metadata.deps[docDepKey][refPtr === subDocPtr ? '#' : refPtr.replace(subDocPtr + '/', '#/')] = refdKey;
+
       // Do not process invalid references
       if (!isValid(refDetails)) {
         return;
@@ -335,9 +338,6 @@ function buildRefModel (document, options, metadata) {
 
       // Record the fully-qualified URI
       refDetails.fqURI = refdKey;
-
-      // Record dependency (relative to the document's sub-document path)
-      metadata.deps[docDepKey][refPtr === subDocPtr ? '#' : refPtr.replace(subDocPtr + '/', '#/')] = refdKey;
 
       // Do not process directly-circular references (to an ancestor or self)
       if (refKey.indexOf(refdKey + '/') === 0) {

--- a/test/browser/documents/nested/test-nested.yaml
+++ b/test/browser/documents/nested/test-nested.yaml
@@ -1,6 +1,8 @@
 name: documents/nested/test-nested.yaml
 child:
   $ref: ./test-nested-1.yaml
+invalid:
+  $ref: 'http://:8080'
 local:
   $ref: '#/name'
 missing:

--- a/test/test-json-refs.js
+++ b/test/test-json-refs.js
@@ -277,6 +277,7 @@ describe('json-refs API', function () {
       local: testNestedDocument1.name,
       missing: testNestedDocument1.missing
     },
+    invalid: testNestedDocument.invalid,
     local: testNestedDocument.name,
     missing: testNestedDocument.missing
   };
@@ -1348,6 +1349,7 @@ describe('json-refs API', function () {
               value: {
                 name: testNestedDocument.name,
                 child: expectedRelativeValue.child,
+                invalid: testNestedDocument.invalid,
                 local: testNestedDocument.name,
                 missing: testNestedDocument.missing
               },
@@ -1448,6 +1450,13 @@ describe('json-refs API', function () {
             def: testDocument.invalid,
             uri: testDocument.invalid.$ref,
             uriDetails: URI.parse(testDocument.invalid.$ref),
+            error: 'HTTP URIs must have a host.',
+            type: 'invalid'
+          };
+          expectedAllResolvedRefs['#/remote/relative/invalid'] = {
+            def: testNestedDocument.invalid,
+            uri: testNestedDocument.invalid.$ref,
+            uriDetails: URI.parse(testNestedDocument.invalid.$ref),
             error: 'HTTP URIs must have a host.',
             type: 'invalid'
           };


### PR DESCRIPTION
Changes:

- The bail out action for invalid references (when building metadata) was happening one step too soon - before it was recorded in the deps property. Moved the check for isValid after the dependency is recored.
- Updated test-nested.yaml to include an invalid reference in the file.
- Updated test-json-refs.js file's "expected" values.