### PR TITLE
Add unit test to that showcases Issue #154

### DIFF
--- a/test/browser/documents/nested/test-nested.yaml
+++ b/test/browser/documents/nested/test-nested.yaml
@@ -5,3 +5,5 @@ local:
   $ref: '#/name'
 missing:
   $ref: '#/some/missing/path'
+remote:
+  $ref: 'https://rawgit.com/whitlockjc/json-refs/master/package.json'


### PR DESCRIPTION
This PR adds a unit test that showcases Issue #154

While I was writing this unit test I realized that the description I initially provided for this issue was not accurate. The real issue is that when only `filter: ['relative']` option is provided the **remote references** contained by any **relative reference** are actually being fully resolved. On the other hand, I could successfully verify that remote references that are directly referenced are not being resolved (as expected).

To demonstrate this issue, I have added a remote reference inside the test file `test-nested.yaml` and created a new unit test that expects this remote reference **NOT** to be resolved. 

I hope this PR is useful to understand this issue. As I said in the issue I'm opened to contribute with a fix. 

Looking forward to your response @whitlockjc 

Cheers!